### PR TITLE
Stop word lists should be sorted.

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -93,7 +93,7 @@ for(var i = 0; i < list.length; i++) {
     f = cm + f;
     f = f.replace(/\{\{locale\}\}/g, list[i].locale);
     f = f.replace(/\{\{stemmerFunction\}\}/g, data.substring(data.indexOf('function')));
-    f = f.replace(/\{\{stopWords\}\}/g, stopWords.replace(/,/g, ' '));
+    f = f.replace(/\{\{stopWords\}\}/g, stopWords.split(',').sort().join(' '));
     f = f.replace(/\{\{stopWordsLength\}\}/g, stopWords.split(',').length + 1);
     f = f.replace(/\{\{languageName\}\}/g, list[i].file.replace(/Stemmer\.js/g, ''));
 


### PR DESCRIPTION
Fixes #7 

Stop word filters use a lunr.SortedSet which requires its elements to be
maintained in a sorted array. This change ensures that the stop words
used to load the sorted set are already sorted.

If the stop words are not presorted then the stop word filter will not
filter all the required stop words.

I have only changed the build script, not included in this commit is the results of running the build, though it did work for me locally. Let me know if you want me to add the results of running the build script to this pull request.