### PR TITLE
update node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ require(['lib/lunr.js', '../lunr.stemmer.support.js', '../lunr.de.js'], function
 # With node.js
 
 ```javascript
-var lunr = require('./lib/lunr.js');
-require('./lunr.stemmer.support.js')(lunr);
-require('./lunr.de.js')(lunr);
+var lunr = require('lunr');
+require('lunr-languages/lunr.stemmer.support')(lunr);
+require('lunr-languages/lunr.de.js')(lunr);
 
 var idx = lunr(function () {
     // use the language (de)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ require(['lib/lunr.js', '../lunr.stemmer.support.js', '../lunr.de.js'], function
 ```
 
 # With node.js
+Install:
+```sh
+npm install lunr lunr-languages
+```
 
+Usage:
 ```javascript
 var lunr = require('lunr');
 require('lunr-languages/lunr.stemmer.support')(lunr);


### PR DESCRIPTION
Most people using node install libraries to `node_modules`, and do not explicit import libraries with full path (according to #10). This doc-update reflects this, and I think it's the "shortest" path for using lunr-languages.