### PR TITLE
add lunr.stemmer.support.js to demo-browser-jp.html

### DIFF
--- a/demos/demo-browser-jp.html
+++ b/demos/demo-browser-jp.html
@@ -4,6 +4,7 @@
     <title></title>
     <meta charset="UTF-8">
     <script src="lib/lunr.js"></script>
+    <script src="../lunr.stemmer.support.js" charset="UTF-8"></script>
     <script src="../tinyseg.js" charset="UTF-8"></script>
     <script src="../lunr.jp.js" charset="UTF-8"></script>
 </head>


### PR DESCRIPTION
Show error messages in runngin demo-browser-jp.html.
- lunr.jp.js:52 Uncaught Error: Lunr stemmer support is not present. Please include / require Lunr stemmer support before this script.
- lunr.js:1197 Uncaught TypeError: Cannot read property 'apply' of undefined

so, add lunr.stemmer.support.js to demo-browser-jp.html