### PR TITLE
Add index file to fix includes require problems with nodejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,18 @@
+
+exports.stemmer = require('./lunr.stemmer.support');
+exports.multi = require('./lunr.multi');
+exports.da = require('./lunr.da');
+exports.de = require('./lunr.de');
+exports.du = require('./lunr.du');
+exports.es = require('./lunr.es');
+exports.fi = require('./lunr.fi');
+exports.fr = require('./lunr.fr');
+exports.hu = require('./lunr.hu');
+exports.it = require('./lunr.it');
+exports.jp = require('./lunr.jp');
+exports.no = require('./lunr.no');
+exports.pt = require('./lunr.pt');
+exports.ro = require('./lunr.ro');
+exports.ru = require('./lunr.ru');
+exports.sv = require('./lunr.sv');
+exports.tr = require('./lunr.tr');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "version": "0.0.4",
     "license": "MPL-1.1",
     "engine": "node 0.10.1",
+    "main": "index.js",
     "devDependencies": {
         "js-beautify": "^1.5.1",
         "uglify-js": "^2.4.15",


### PR DESCRIPTION
I got some problems with nodejs and the migration from npm 2 to npm 3. This is a proposal to fix the issue, with for example:

const lunrLanguages = require('lunr-languages');
...
lunrLanguages.stemmer(lunr);
lunrLanguages.fr(lunr);

npm 2 and npm 3 do not host file at the same place so direct use of require() is not possible