### PR TITLE
load nodejieba dict on init

### DIFF
--- a/lunr.zh.js
+++ b/lunr.zh.js
@@ -64,6 +64,8 @@
 
     /* register specific locale function */
     lunr.zh = function() {
+      nodejiebaDictJson && nodejieba.load(nodejiebaDictJson)
+      
       this.pipeline.reset();
       this.pipeline.add(
         lunr.zh.trimmer,
@@ -89,8 +91,6 @@
       if (Array.isArray(obj)) return obj.map(function(t) {
         return isLunr2 ? new lunr.Token(t.toLowerCase()) : t.toLowerCase()
       })
-
-      nodejiebaDictJson && nodejieba.load(nodejiebaDictJson)
 
       var str = obj.toString().trim().toLowerCase();
       var tokens = [];


### PR DESCRIPTION
`lunr.zh.js` will try to load `nodejieba` dict on EVERY tokenization call currently. So CPU usage will be 100% while indexing a Chinese document with custom a `nodejieba` dict.
https://github.com/MihaiValentin/lunr-languages/blob/177653fb567006478ccb0ab6920b78eb77cad14e/lunr.zh.js#L87-L93

I think the dict should only be loaded once at initialization.