### PR TITLE
Add TypeScript declarations and module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ const idx = lunr(function () {
 });
 ```
 
+The existing CommonJS usage is still supported. Modern runtimes and TypeScript projects can import the same subpath modules:
+
+```javascript
+import lunr from 'lunr';
+import stemmerSupport from 'lunr-languages/lunr.stemmer.support';
+import de from 'lunr-languages/lunr.de';
+
+stemmerSupport(lunr);
+de(lunr);
+```
+
+Type declarations are included for the registration modules and the Lunr properties they install, including `lunr.multiLanguage`.
+
 For Spanish indexes on Lunr 2, you can opt into accent-insensitive matching by expanding accented tokens before stemming:
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lunr-languages",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lunr-languages",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "MPL-1.1",
       "devDependencies": {
         "js-beautify": "^1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lunr-languages",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lunr-languages",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MPL-1.1",
       "devDependencies": {
         "js-beautify": "^1.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lunr-languages",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lunr-languages",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MPL-1.1",
       "devDependencies": {
         "js-beautify": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lunr-languages",
   "description": "A a collection of languages stemmers and stopwords for Lunr Javascript library",
   "author": "Mihai Valentin (http://www.mihaivalentin.com)",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "MPL-1.1",
   "engine": "node 0.10.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,89 @@
   "author": "Mihai Valentin (http://www.mihaivalentin.com)",
   "version": "1.18.0",
   "license": "MPL-1.1",
+  "type": "commonjs",
+  "types": "./types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "lunr.*.js": [
+        "types/plugin.d.ts"
+      ],
+      "lunr.*": [
+        "types/plugin.d.ts"
+      ],
+      "min/lunr.*.min.js": [
+        "types/plugin.d.ts"
+      ],
+      "min/lunr.*.min": [
+        "types/plugin.d.ts"
+      ],
+      "tinyseg.js": [
+        "types/plugin.d.ts"
+      ],
+      "tinyseg": [
+        "types/plugin.d.ts"
+      ],
+      "wordcut.js": [
+        "types/wordcut.d.ts"
+      ],
+      "wordcut": [
+        "types/wordcut.d.ts"
+      ]
+    }
+  },
   "engine": "node 0.10.1",
+  "exports": {
+    "./package.json": "./package.json",
+    "./lunr.*.js": {
+      "types": "./types/plugin.d.ts",
+      "import": "./lunr.*.js",
+      "require": "./lunr.*.js",
+      "default": "./lunr.*.js"
+    },
+    "./lunr.*": {
+      "types": "./types/plugin.d.ts",
+      "import": "./lunr.*.js",
+      "require": "./lunr.*.js",
+      "default": "./lunr.*.js"
+    },
+    "./min/lunr.*.min.js": {
+      "types": "./types/plugin.d.ts",
+      "import": "./min/lunr.*.min.js",
+      "require": "./min/lunr.*.min.js",
+      "default": "./min/lunr.*.min.js"
+    },
+    "./min/lunr.*.min": {
+      "types": "./types/plugin.d.ts",
+      "import": "./min/lunr.*.min.js",
+      "require": "./min/lunr.*.min.js",
+      "default": "./min/lunr.*.min.js"
+    },
+    "./tinyseg.js": {
+      "types": "./types/plugin.d.ts",
+      "import": "./tinyseg.js",
+      "require": "./tinyseg.js",
+      "default": "./tinyseg.js"
+    },
+    "./tinyseg": {
+      "types": "./types/plugin.d.ts",
+      "import": "./tinyseg.js",
+      "require": "./tinyseg.js",
+      "default": "./tinyseg.js"
+    },
+    "./wordcut.js": {
+      "types": "./types/wordcut.d.ts",
+      "import": "./wordcut.js",
+      "require": "./wordcut.js",
+      "default": "./wordcut.js"
+    },
+    "./wordcut": {
+      "types": "./types/wordcut.d.ts",
+      "import": "./wordcut.js",
+      "require": "./wordcut.js",
+      "default": "./wordcut.js"
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "build": "node build/build.js",
     "test": "mocha test/*Test.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lunr-languages",
   "description": "A a collection of languages stemmers and stopwords for Lunr Javascript library",
   "author": "Mihai Valentin (http://www.mihaivalentin.com)",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "license": "MPL-1.1",
   "engine": "node 0.10.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lunr-languages",
   "description": "A a collection of languages stemmers and stopwords for Lunr Javascript library",
   "author": "Mihai Valentin (http://www.mihaivalentin.com)",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "MPL-1.1",
   "engine": "node 0.10.1",
   "scripts": {

--- a/test/ModuleResolutionTest.js
+++ b/test/ModuleResolutionTest.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+
+function runNode(args) {
+  var result = childProcess.spawnSync(process.execPath, args, {
+    cwd: __dirname + '/..',
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+describe('Package module resolution', function() {
+  it('supports existing CommonJS subpath imports', function() {
+    var script = [
+      "var ids = ['lunr-languages/lunr.de', 'lunr-languages/lunr.de.js', 'lunr-languages/min/lunr.de.min', 'lunr-languages/min/lunr.de.min.js', 'lunr-languages/tinyseg'];",
+      "ids.forEach(function(id) {",
+      "  if (typeof require(id) !== 'function') throw new Error(id);",
+      "});"
+    ].join('\n');
+
+    runNode([
+      '-e',
+      script
+    ]);
+  });
+
+  it('supports ESM subpath imports without file extensions', function() {
+    var script = [
+      "var ids = ['lunr-languages/lunr.de', 'lunr-languages/lunr.stemmer.support', 'lunr-languages/min/lunr.de.min', 'lunr-languages/tinyseg'];",
+      "for (const id of ids) {",
+      "  const mod = await import(id);",
+      "  if (typeof mod.default !== 'function') throw new Error(id);",
+      "}"
+    ].join('\n');
+
+    runNode([
+      '--input-type=module',
+      '-e',
+      script
+    ]);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="./lunr.d.ts" />
+
+export {};

--- a/types/lunr.d.ts
+++ b/types/lunr.d.ts
@@ -1,0 +1,59 @@
+declare namespace lunr {
+  interface LunrLanguagesPlugin {
+    (this: any, ...args: any[]): void;
+  }
+
+  interface LunrLanguagesPipelineFunction {
+    (token: any, i?: number, tokens?: any[]): any;
+    label?: string;
+  }
+
+  interface LunrLanguagesLanguage extends LunrLanguagesPlugin {
+    wordCharacters?: string;
+    trimmer?: LunrLanguagesPipelineFunction;
+    stemmer?: LunrLanguagesPipelineFunction;
+    stopWordFilter?: LunrLanguagesPipelineFunction;
+    tokenizer?: (obj?: any, metadata?: any) => any[];
+    accentFold?: LunrLanguagesPipelineFunction;
+    [key: string]: any;
+  }
+
+  function multiLanguage(...languages: string[]): LunrLanguagesPlugin;
+
+  var ar: LunrLanguagesLanguage;
+  var da: LunrLanguagesLanguage;
+  var de: LunrLanguagesLanguage;
+  var du: LunrLanguagesLanguage;
+  var el: LunrLanguagesLanguage;
+  var es: LunrLanguagesLanguage;
+  var fi: LunrLanguagesLanguage;
+  var fr: LunrLanguagesLanguage;
+  var he: LunrLanguagesLanguage;
+  var hi: LunrLanguagesLanguage;
+  var hu: LunrLanguagesLanguage;
+  var hy: LunrLanguagesLanguage;
+  var it: LunrLanguagesLanguage;
+  var ja: LunrLanguagesLanguage;
+  var jp: LunrLanguagesLanguage;
+  var kn: LunrLanguagesLanguage;
+  var ko: LunrLanguagesLanguage;
+  var nl: LunrLanguagesLanguage;
+  var no: LunrLanguagesLanguage;
+  var pl: LunrLanguagesLanguage;
+  var pt: LunrLanguagesLanguage;
+  var ro: LunrLanguagesLanguage;
+  var ru: LunrLanguagesLanguage;
+  var sa: LunrLanguagesLanguage;
+  var sv: LunrLanguagesLanguage;
+  var ta: LunrLanguagesLanguage;
+  var te: LunrLanguagesLanguage;
+  var th: LunrLanguagesLanguage;
+  var tr: LunrLanguagesLanguage;
+  var vi: LunrLanguagesLanguage;
+  var zh: LunrLanguagesLanguage;
+
+  var stemmerSupport: any;
+  var trimmerSupport: any;
+  var TinySegmenter: any;
+  var wordcut: any;
+}

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -1,0 +1,13 @@
+/// <reference path="./lunr.d.ts" />
+
+declare namespace LunrLanguages {
+  interface LunrLike {
+    [key: string]: any;
+  }
+
+  type Plugin = (lunr: LunrLike, ...options: any[]) => void;
+}
+
+declare const plugin: LunrLanguages.Plugin;
+
+export = plugin;

--- a/types/wordcut.d.ts
+++ b/types/wordcut.d.ts
@@ -1,0 +1,3 @@
+declare const wordcut: any;
+
+export = wordcut;


### PR DESCRIPTION
## Summary

- Add bundled TypeScript declarations for the language registration modules and installed Lunr properties.
- Add package export and type-version metadata for extensionless subpath imports in CommonJS, ESM, and TypeScript consumers.
- Add regression coverage for existing CommonJS subpaths and modern ESM subpaths.

## Validation

- npm test
- tsc --noEmit --module Node16 --moduleResolution node16 --strict --esModuleInterop /private/tmp/lunr-languages-pr-types/esm.mts
- tsc --noEmit --module Node16 --moduleResolution node16 --strict /private/tmp/lunr-languages-pr-types/cjs.cts
- tsc --noEmit --module commonjs --moduleResolution node --strict /private/tmp/lunr-languages-pr-types/classic.ts
- npm pack --dry-run --json