### PR TITLE
Fix broken hy/ko/vi trimmers

### DIFF
--- a/lunr.hy.js
+++ b/lunr.hy.js
@@ -63,11 +63,10 @@
 
     /* lunr trimmer function */
     // http://www.unicode.org/charts/
-    lunr.hy.wordCharacters = "[" +
+    lunr.hy.wordCharacters =
       "A-Za-z" +
       "\u0530-\u058F" + // armenian alphabet
-      "\uFB00-\uFB4F" + // armenian ligatures
-      "]";
+      "\uFB00-\uFB4F"; // armenian ligatures
     lunr.hy.trimmer = lunr.trimmerSupport.generateTrimmer(lunr.hy.wordCharacters);
 
     lunr.Pipeline.registerFunction(lunr.hy.trimmer, 'trimmer-hy');

--- a/lunr.ko.js
+++ b/lunr.ko.js
@@ -80,10 +80,9 @@
     };
 
     /* lunr trimmer function */
-    lunr.ko.wordCharacters = "[" +
+    lunr.ko.wordCharacters =
       "A-Za-z" +
-      "\uac00-\ud7a3" +
-      "]";
+      "\uac00-\ud7a3";
     lunr.ko.trimmer = lunr.trimmerSupport.generateTrimmer(lunr.ko.wordCharacters);
 
     lunr.Pipeline.registerFunction(lunr.ko.trimmer, 'trimmer-ko');

--- a/lunr.vi.js
+++ b/lunr.vi.js
@@ -62,7 +62,7 @@
     };
 
     /* lunr trimmer function */
-    lunr.vi.wordCharacters = "[" +
+    lunr.vi.wordCharacters =
       "A-Za-z" +
       "\u0300\u0350" + // dấu huyền
       "\u0301\u0351" + // dấu sắc
@@ -75,8 +75,7 @@
       "\u0102-\u0103" + // Ă
       "\u0110-\u0111" + // Đ
       "\u01A0-\u01A1" + // Ơ
-      "\u01AF-\u01B0" + // Ư
-      "]";
+      "\u01AF-\u01B0"; // Ư
     lunr.vi.trimmer = lunr.trimmerSupport.generateTrimmer(lunr.vi.wordCharacters);
     lunr.Pipeline.registerFunction(lunr.vi.trimmer, 'trimmer-vi');
     lunr.vi.stopWordFilter = lunr.generateStopWordFilter('là cái nhưng mà'.split(' '));

--- a/test/VersionsAndLanguagesTest.js
+++ b/test/VersionsAndLanguagesTest.js
@@ -171,6 +171,30 @@ lunrVersions.forEach(function (lunrVersion) {
                 });
             }
         });
+        describe("should trim punctuation around locale words in language trimmers", function () {
+            delete require.cache[require.resolve('./lunr/' + lunrVersion.lunr)]
+
+            var lunr = require('./lunr/' + lunrVersion.lunr);
+            require('../lunr.stemmer.support.js')(lunr);
+            require('../lunr.ko.js')(lunr);
+            require('../lunr.hy.js')(lunr);
+            require('../lunr.vi.js')(lunr);
+
+            it("should trim Korean punctuation", function () {
+                assert.equal(lunr.ko.trimmer('(한국어)'), '한국어')
+                assert.equal(lunr.ko.trimmer('한국어,'), '한국어')
+            });
+
+            it("should trim Armenian punctuation", function () {
+                assert.equal(lunr.hy.trimmer('(միսը)'), 'միսը')
+                assert.equal(lunr.hy.trimmer('միսը,'), 'միսը')
+            });
+
+            it("should trim Vietnamese punctuation", function () {
+                assert.equal(lunr.vi.trimmer('(đình)'), 'đình')
+                assert.equal(lunr.vi.trimmer('đình,'), 'đình')
+            });
+        });
         describe("should normalize German wildcard queries with umlauts", function () {
             delete require.cache[require.resolve('./lunr/' + lunrVersion.lunr)]
 


### PR DESCRIPTION
These languages included brackets around their wordCharacters list. When passed to generateTrimmer it would get wrapped in another set of brackets, producing an invalid regex. Effectively, the trimmers did nothing (the added regression test would fail without the fixes). I do not speak any of these languages so I'll cc the original authors to try to make sure I'm not missing what the original intent was.

@turbobit @v4nn4 @billmoyers